### PR TITLE
Initial commit for positioners, included an Identity and Stacked positioner

### DIFF
--- a/examples.js
+++ b/examples.js
@@ -8,7 +8,7 @@
         // Define graphics ...
 
         var scatterplot = gg({
-            layers: [{ geometry: 'point', mapping: { x: 'd', y: 'r' } }]
+            layers: [{ geometry: 'point', mapping: { x: 'd', y: 'r' },  }]
         });
 
         var symmetric = gg({
@@ -22,8 +22,8 @@
 
         var linechart = gg({
             layers: [
-                { geometry: 'line', mapping: { x: 'd', y: 'r', group: 'subject', color: 'subject'} },
-                { geometry: 'text', mapping: { x: 'd', y: 'r', text: '{d}, {r}' },  show: "hover" }
+                { geometry: 'line', mapping: { x: 'd', y: 'r', group: 'subject', color: 'subject'}, positioner: { kind: 'stack' } },
+                { geometry: 'text', mapping: { x: 'd', y: 'r', text: '{d}, {r}' }, show: "hover" }
             ],
             scales: [
                 { aesthetic: 'color', type: 'color', range: ['#CFF09E', '#A8DBA8', '#79BD9A', '#3B8686'] }
@@ -128,7 +128,7 @@
         var h    = 200;
         var ex   = function () { return d3.select('#examples').append('span'); };
 
-        //symmetric.render(w, h, ex(), data.toBeCentered);
+        symmetric.render(w, h, ex(), data.toBeCentered);
         linechart.renderer(w, h, ex())(data.upwardSubjects);
         combined.renderer(w, h, ex())(data.upward);
         barchart.renderer(w, h, ex())(data.upward);
@@ -138,6 +138,6 @@
         heightHistogram.renderer(w, h, ex())(data.heightWeight);
         twoPopulations.renderer(w, h, ex())(data.twoPopulations);
         boxplot.renderer(w, h, ex())(data.forBoxPlots);
-        area.renderer(w, h, ex())(data.upwardSubjects);
+        //area.renderer(w, h, ex())(data.upwardSubjects);
     });
 })();

--- a/examples.js
+++ b/examples.js
@@ -124,13 +124,11 @@
 
         var stackedArea = gg({
             layers: [
-                { geometry: 'area', mapping: { x: 'd', y: 'r', group: 'subject', fill: 'subject'}, alpha: 0.8, width: 0, positioner: { kind: 'stack' } },
-                { geometry: 'line', mapping: { x: 'd', y: 'r', group: 'subject', color: 'subject'}, positioner: { kind: 'stack' }, interpolate: 'basis' } 
+                { geometry: 'area', mapping: { x: 'd', y: 'r', group: 'subject', fill: 'subject'}, alpha: 0.8, width: 0, positioner: { kind: 'stack' } }
             ],
             scales: [
                 { aesthetic: 'y', type: 'linear', min: 0 },
-                { aesthetic: 'fill', type: 'color', range: ['#CFF09E', '#A8DBA8', '#79BD9A', '#3B8686'] },
-                { aesthetic: 'color', type: 'color', range: ['#CFF09E', '#A8DBA8', '#79BD9A', '#3B8686'] }
+                { aesthetic: 'fill', type: 'color', range: ['#CFF09E', '#A8DBA8', '#79BD9A', '#3B8686'] }
             ]
         });
 

--- a/examples.js
+++ b/examples.js
@@ -106,6 +106,18 @@
             scales: [ { aesthetic: 'size', range: [ 1, 5 ]} ]
         });
 
+        var area = gg({
+            layers: [
+                { geometry: 'area', mapping: { x: 'd', y: 'r', y0: 'r', y1: 'r', group: 'subject', color: 'subject'} }
+            ],
+            scales: [
+                { aesthetic: 'y0', type: 'linear' },
+                { aesthetic: 'y1', type: 'linear' }
+
+            ]
+        });
+
+
         // ... and render 'em
 
         var data = gg.sampleData;
@@ -124,5 +136,6 @@
         heightHistogram.render(w, h, ex(), data.heightWeight);
         twoPopulations.render(w, h, ex(), data.twoPopulations);
         boxplot.render(w, h, ex(), data.forBoxPlots);
+        area.render(w, h, ex(), data.upwardSubjects);
     });
 })();

--- a/examples.js
+++ b/examples.js
@@ -115,15 +115,24 @@
 
         var area = gg({
             layers: [
-                { geometry: 'area', mapping: { x: 'd', y: 'r', y0: 'r', y1: 'r', group: 'subject', color: 'subject'} }
+                { geometry: 'area', mapping: { x: 'd', y: 'r', group: 'subject', fill: 'subject'}, alpha: 0.6 }
             ],
             scales: [
-                { aesthetic: 'y0', type: 'linear' },
-                { aesthetic: 'y1', type: 'linear' }
-
+                { aesthetic: 'fill', type: 'color', range: ['#CFF09E', '#A8DBA8', '#79BD9A', '#3B8686'] }
             ]
         });
 
+        var stackedArea = gg({
+            layers: [
+                { geometry: 'area', mapping: { x: 'd', y: 'r', group: 'subject', fill: 'subject'}, alpha: 0.8, width: 0, positioner: { kind: 'stack' } },
+                { geometry: 'line', mapping: { x: 'd', y: 'r', group: 'subject', color: 'subject'}, positioner: { kind: 'stack' }, interpolate: 'basis' } 
+            ],
+            scales: [
+                { aesthetic: 'y', type: 'linear', min: 0 },
+                { aesthetic: 'fill', type: 'color', range: ['#CFF09E', '#A8DBA8', '#79BD9A', '#3B8686'] },
+                { aesthetic: 'color', type: 'color', range: ['#CFF09E', '#A8DBA8', '#79BD9A', '#3B8686'] }
+            ]
+        });
 
         // ... and render 'em
 
@@ -131,10 +140,11 @@
         var w    = 300;
         var h    = 200;
         var ex   = function () { return d3.select('#examples').append('span'); };
+        var cloneData = function (dset) { return _.map(dset, function (point) { return _.clone(point); }) };
 
         //symmetric.render(w, h, ex(), data.toBeCentered);
         linechart.renderer(w, h, ex())(data.upwardSubjects);
-        stackedLinechart.renderer(w, h, ex())(data.upwardSubjects);
+        stackedLinechart.renderer(w, h, ex())(cloneData(data.upwardSubjects));
         combined.renderer(w, h, ex())(data.upward);
         barchart.renderer(w, h, ex())(data.upward);
         quadrants.renderer(w, h, ex())(data.quadrants);
@@ -143,6 +153,7 @@
         heightHistogram.renderer(w, h, ex())(data.heightWeight);
         twoPopulations.renderer(w, h, ex())(data.twoPopulations);
         boxplot.renderer(w, h, ex())(data.forBoxPlots);
-        //area.renderer(w, h, ex())(data.upwardSubjects);
+        area.renderer(w, h, ex())(data.upwardSubjects);
+        stackedArea.renderer(w, h, ex())(cloneData(data.upwardSubjects));
     });
 })();

--- a/examples.js
+++ b/examples.js
@@ -20,15 +20,19 @@
             ]
         });
 
-        var linechart = gg({
+        var linechartSpec = {
             layers: [
-                { geometry: 'line', mapping: { x: 'd', y: 'r', group: 'subject', color: 'subject'}, positioner: { kind: 'stack' } },
+                { geometry: 'line', mapping: { x: 'd', y: 'r', group: 'subject', color: 'subject'} },
                 { geometry: 'text', mapping: { x: 'd', y: 'r', text: '{d}, {r}' }, show: "hover" }
             ],
             scales: [
                 { aesthetic: 'color', type: 'color', range: ['#CFF09E', '#A8DBA8', '#79BD9A', '#3B8686'] }
             ]
-        });
+        };
+
+        var linechart = gg(linechartSpec);
+        linechartSpec.layers[0].positioner = { kind: 'stack' };
+        var stackedLinechart = gg(linechartSpec);
 
         var barchart = gg({
             layers: [{ geometry: 'interval', mapping: { x: 'd', y: 'r' }, color: 'blue', width: 2 }]
@@ -130,6 +134,7 @@
 
         //symmetric.render(w, h, ex(), data.toBeCentered);
         linechart.renderer(w, h, ex())(data.upwardSubjects);
+        stackedLinechart.renderer(w, h, ex())(data.upwardSubjects);
         combined.renderer(w, h, ex())(data.upward);
         barchart.renderer(w, h, ex())(data.upward);
         quadrants.renderer(w, h, ex())(data.quadrants);

--- a/examples.js
+++ b/examples.js
@@ -8,12 +8,12 @@
         // Define graphics ...
 
         var scatterplot = gg({
-            layers: [{ geometry: 'point', mapping: { x: 'd', y: 'r' },  }]
+            layers: [{ geometry: 'point', mapping: { x: 'd', y: 'r' } }]
         });
 
         var symmetric = gg({
             layers: [
-                { geometry: 'line', mapping: { x: 'd', y: 'r' } },
+                { geometry: 'line', mapping: { x: 'd', y: 'r' } }
             ],
             scales: [
                 { type: 'linear', aesthetic: 'y', center: 0 }
@@ -128,7 +128,7 @@
         var h    = 200;
         var ex   = function () { return d3.select('#examples').append('span'); };
 
-        symmetric.render(w, h, ex(), data.toBeCentered);
+        //symmetric.render(w, h, ex(), data.toBeCentered);
         linechart.renderer(w, h, ex())(data.upwardSubjects);
         combined.renderer(w, h, ex())(data.upward);
         barchart.renderer(w, h, ex())(data.upward);

--- a/gg.css
+++ b/gg.css
@@ -68,3 +68,6 @@ div#examples span { margin: 3px; }
   fill: black;
   text-shadow: 1px 1px 0px white;
 }
+
+.area path {
+}

--- a/gg.js
+++ b/gg.js
@@ -837,8 +837,8 @@
 
     function StackPositioner (spec) {
         var stack = this.positioner = d3.layout.stack();
-        spec.offset !== 'undefined' && (stack.offset(spec.offset));
-        spec.order  !== 'undefined' && (stack.order(spec.order));
+        spec.offset !== undefined && (stack.offset(spec.offset));
+        spec.order  !== undefined && (stack.order(spec.order));
     }
 
     StackPositioner.prototype.position = function (data, mappings) {

--- a/gg.js
+++ b/gg.js
@@ -318,13 +318,13 @@
 
     AreaGeometry.prototype.render = function (g, data) {
         var layer = this.layer;
-        function scale (d, key, aesthetic) { return layer.scaleExtracted(d[key], aesthetic, d); }
+        function scale (d, key, aesthetic) { return layer.scaleExtracted(d[layer.mappings[key]], aesthetic, d); }
 
         var area = d3.svg.area()
-                         .x(function (d) { return scale(d, "x", "x") })
-                         .y1(function(d) { return scale(d, "y1", "y") })
-                         .y0(function (d) { return scale(d, "y0", "y") })
-                         .interpolate("basis")
+            .x(function (d) { return scale(d, "x", "x") })
+            .y1(function(d) { return scale(d, "y1", "y") })
+            .y0(function (d) { return scale(d, "y0", "y") })
+            .interpolate("basis");
 
         groups(g, 'lines', data).selectAll('polyline')
             .data(function(d) { return [d]; })
@@ -335,7 +335,7 @@
             .attr('stroke', this.stroke)
             .attr('fill', this.fill)
             .attr('fill-opacity', this.alpha)
-            .attr('stroke-opacity', this.alpha)
+            .attr('stroke-opacity', this.alpha);
     };
 
     function LineGeometry (spec) {


### PR DESCRIPTION
Because positioners may add attributes to data objects that affect
the calculation of scale domains, the logic for calculating the domain has been
moved to the positioner objects.

Note this is a first pass and I'd appreciate feedback on the general
implementation. Of particular note is the fact that only the line geom
currently supports stacking and other geoms will require some effort to be made
compatible. Also note the specialized scale method now present in the Area and
Line geoms suggesting a more generalized version may be more appropriate.
